### PR TITLE
Remove unnecessary option

### DIFF
--- a/config.json
+++ b/config.json
@@ -100,7 +100,7 @@
             "enableCustomColor":false,
             "color":"#ffffff",
 
-            "options":["general","apply"],
+            "options":["general"],
             "enableTicketExplaination":true,
             "enableMaxTicketsWarning":true
         }


### PR DESCRIPTION
Option doesn't exist and causes a warning in the console