### PR TITLE
Feature Reaction Role Logs

### DIFF
--- a/src/actions/reactionRole.ts
+++ b/src/actions/reactionRole.ts
@@ -4,6 +4,8 @@
 import {opendiscord, api, utilities} from "../index"
 import * as discord from "discord.js"
 
+const generalConfig = opendiscord.configs.get("opendiscord:general")
+
 export const registerActions = async () => {
     opendiscord.actions.add(new api.ODAction("opendiscord:reaction-role"))
     opendiscord.actions.get("opendiscord:reaction-role").workers.add([
@@ -79,6 +81,11 @@ export const registerActions = async () => {
 
             //update instance & finish event
             instance.result = result
+
+            if (generalConfig.data.system.logs.enabled && generalConfig.data.system.messages.roleAdding.logs){
+                const logChannel = opendiscord.posts.get("opendiscord:logs")
+                if (logChannel) { logChannel.send( await opendiscord.builders.messages.getSafe("opendiscord:reaction-role-logs").build(source,{guild,user,role,result}))}}
+
             await opendiscord.events.get("afterRolesUpdated").emit([user,role])
         }),
         new api.ODWorker("opendiscord:logs",0,(instance,params,source,cancel) => {

--- a/src/builders/embeds.ts
+++ b/src/builders/embeds.ts
@@ -1107,7 +1107,44 @@ const roleEmbeds = () => {
             else instance.setDescription(lang.getTranslation("actions.descriptions.rolesEmpty"))
         })
     )
+
+    //REACTION ROLE LOGS
+    embeds.add(new api.ODEmbed("opendiscord:reaction-role-logs"))
+    embeds.get("opendiscord:reaction-role-logs")!.workers.add(
+        new api.ODWorker("opendiscord:reaction-role-logs",0,async (instance,params,source) => {
+            const {user,result} = params
+
+            const newResult = result
+                .filter(r => r.action != null && r.role?.id)
+                .sort((a, b) => {
+                    if (a.action === "added" && b.action === "removed") return -1;
+                    if (a.action === "removed" && b.action === "added") return 1;
+                    return 0;
+                })
+                .map(r => {
+                    return (r.action === "added")
+                        ? `🟢${lang.getTranslation("params.uppercase.added")} ${discord.roleMention(r.role.id)}`
+                        : `🔴 ${lang.getTranslation("params.uppercase.removed")} ${discord.roleMention(r.role.id)}`
+                })
+
+            let baseDescription = lang.getTranslationWithParams("actions.logs.roleLog", [discord.userMention(user.id)])
+            if (!baseDescription || baseDescription === "null") {
+                baseDescription = `Roles updated for ${discord.userMention(user.id)}`
+            }
+
+            const fullDescription = (newResult.length > 0) ? `${baseDescription}\n\n${newResult.join("\n")}` : `${baseDescription}\n\n${lang.getTranslation("actions.descriptions.rolesEmpty")}`
+
+            instance.setColor(generalConfig.data.mainColor)
+            instance.setTitle(utilities.emojiTitle("📋", lang.getTranslation("actions.titles.roles")))
+            instance.setThumbnail(user.displayAvatarURL())
+            instance.setAuthor(user.displayName, user.displayAvatarURL())
+            instance.setTimestamp(new Date())
+            instance.setDescription(fullDescription)
+        })
+    )
 }
+
+export default roleEmbeds
 
 const clearEmbeds = () => {
     //CLEAR VERIFY MESSAGE

--- a/src/builders/messages.ts
+++ b/src/builders/messages.ts
@@ -964,6 +964,16 @@ const roleMessages = () => {
             instance.setEphemeral(true)
         })
     )
+
+    //REACTION ROLE LOGS
+    messages.add(new api.ODMessage("opendiscord:reaction-role-logs"))
+    messages.get("opendiscord:reaction-role-logs")!.workers.add(
+        new api.ODWorker("opendiscord:reaction-role-logs",0,async(instance,params,source) => {
+            const {guild,user,role,result} = params
+            const embed = await embeds.getSafe("opendiscord:reaction-role-logs").build(source,{guild,user,role,result})
+            instance.addEmbed(embed)
+        })
+    )
 }
 
 const clearMessages = () => {


### PR DESCRIPTION
This pull request introduces a new feature that logs user interactions with reaction roles. Specifically, it adds functionality to track when users add or remove reaction roles in the server. These events are now logged for better traceability and moderation.

The implementation includes updates to the reactionRole.ts file, where the core logic for detecting reaction role changes has been enhanced to trigger log generation. Supporting updates were also made to messages.ts and embeds.ts to construct consistent and informative log messages that follow the bot’s existing formatting.

By logging reaction role activity, this feature provides server admins with better visibility into user actions, making it easier to audit permissions and manage automated role assignments. 

Fixes Issues Reaction Role Logs #165