### PR TITLE
fix: improve Server Id Missing error message with config hint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,7 +367,7 @@ const main = async () => {
             const botServers = await client.getGuilds()
             const generalConfig = opendiscord.configs.get("opendiscord:general")
             const serverId = generalConfig.data.serverId ? generalConfig.data.serverId : ""
-            if (!serverId) throw new api.ODSystemError("Server Id Missing!")
+            if (!serverId) throw new api.ODSystemError("Server Id Missing! Please set 'serverId' in config/general.jsonc.")
             
             const mainServer = botServers.find((g) => g.id == serverId)
             client.mainServer = mainServer ?? null


### PR DESCRIPTION
Improve the 'Server Id Missing' error message to include a hint about checking the config file.