### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ With the amazing support of our translators, we've been able to translate Open T
 If you enjoy using Open ticket, **consider starring** our repository.  
 This will help us grow and reach even more people!
 
-<a href="https://star-history.com/#open-discord-bots/open-ticket&Date">
+<a href="https://star-history.dera.page/#open-discord-bots/open-ticket&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-discord-bots/open-ticket&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-discord-bots/open-ticket&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-discord-bots/open-ticket&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-discord-bots/open-ticket&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-discord-bots/open-ticket&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-discord-bots/open-ticket&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in our README is currently broken because of GitHub's stargazer API restrictions, which prevents the chart from loading. This PR updates the chart to use a working data source so the star history renders correctly again. Thanks for taking a look!